### PR TITLE
Added two dataframes which takes paths to .parquet files as input

### DIFF
--- a/SparksInTheDark/src/main/scala/SparksInTheDarkMain.scala
+++ b/SparksInTheDark/src/main/scala/SparksInTheDarkMain.scala
@@ -6,6 +6,17 @@ object SparksInTheDarkMain {
       .getOrCreate()
 
     // Read in data from parquet
+    val df_background = spark.read
+      .parquet("data/ntuple_em_v2.parquet")
+
+    df_background.show()
+    df_background.printSchema()
+
+    val df_signal = spark.read
+      .parquet("data/ntuple_SU2L_25_500_v2.parquet")
+
+    df_signal.show()
+    df_signal.printSchema()
 
     // Create histogram as outlined in SparkDensityTree-Introduction.scala
 


### PR DESCRIPTION
Two dataframes are now created in the main function. Both dataframes read the wanted .parquet files using spark.read, and one can check the dataframes using ```dataframe.show()``` & ```dataframe.printSchema()```